### PR TITLE
manifest: Use lineage qcom-caf trees by default

### DIFF
--- a/snippets/los.xml
+++ b/snippets/los.xml
@@ -90,8 +90,8 @@
 
 
   <!-- Display HALS -->
-  <project path="hardware/qcom-caf/msm8996/display" name="android_hardware_qcom_display" revision="dot11-caf-msm8996" remote="dot" />
-  <project path="hardware/qcom-caf/msm8996-los/display" name="android_hardware_qcom_display" revision="lineage-18.1-caf-msm8996" remote="lineage" />
+  <project path="hardware/qcom-caf/msm8996-dot/display" name="android_hardware_qcom_display" revision="dot11-caf-msm8996" remote="dot" />
+  <project path="hardware/qcom-caf/msm8996/display" name="android_hardware_qcom_display" revision="lineage-18.1-caf-msm8996" remote="lineage" />
   <project path="hardware/qcom-caf/msm8998/display" name="android_hardware_qcom_display" revision="lineage-18.1-caf-msm8998" remote="lineage" />
   <project path="hardware/qcom-caf/sdm845/display" name="android_hardware_qcom_display" revision="lineage-18.1-caf-sdm845" remote="lineage" />
   <project path="hardware/qcom-caf/sm8150/display" name="android_hardware_qcom_display" revision="lineage-18.1-caf-sm8150" remote="lineage" />


### PR DESCRIPTION
As some special Qualcomm chipsets are not supported by dot trees, switch to lineage tree by default