### PR TITLE
manifest: track external colorkt and themelib resources

### DIFF
--- a/snippets/dot.xml
+++ b/snippets/dot.xml
@@ -67,6 +67,7 @@
   <project path="external/faceunlock" name="external_faceunlock" remote="pixel-gitlab-self-hosted" />
   <project path="external/boringssl" name="android_external_boringssl" remote="dot" />
   <project path="external/cldr" name="android_external_cldr" remote="dot" />
+  <project path="external/colorkt" name="android_external_colorkt" remote="dot" />
   <project path="external/e2fsprogs" name="android_external_e2fsprogs" remote="dot" />
   <project path="external/gptfdisk" name="android_external_gptfdisk" remote="dot" />
   <project path="external/guice" name="android_external_guice" remote="dot" />
@@ -74,6 +75,7 @@
   <project path="external/libcxx" name="android_external_libcxx" remote="dot" />
   <project path="external/perfetto" name="android_external_perfetto" remote="dot" />
   <project path="external/selinux" name="android_external_selinux" remote="dot" />
+  <project path="external/themelib" name="android_external_themelib" remote="dot" />
   <project path="external/tinyalsa" name="android_external_tinyalsa" remote="dot" />
   <project path="external/tinycompress" name="android_external_tinycompress" remote="dot" />
   <project path="external/toybox" name="android_external_toybox" remote="dot" />


### PR DESCRIPTION
cause the following error:
error: frameworks/base/packages/SystemUI/Android.bp:69:1: "SystemUI-core" depends on undefined module "colorkt"
error: frameworks/base/packages/SystemUI/Android.bp:69:1: "SystemUI-core" depends on undefined module "themelib"