### PR TITLE
README.md: Change git:// to http://

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To get started with the building process, you'll need to get familiar with [Git 
 To initialize your local repository, use a command like this:
 
 ```bash
-repo init -u git://github.com/DotOS/manifest.git -b dot11
+repo init -u http://github.com/DotOS/manifest.git -b dot11
 ```
 
 Then to sync up:


### PR DESCRIPTION
Github no longer provides unauthorized GIT port and thus repo init will either fail or wait for timeout.